### PR TITLE
Fix "Prefer `format()` over string interpolation operator" issue

### DIFF
--- a/dashday/main.py
+++ b/dashday/main.py
@@ -84,7 +84,7 @@ def main():
     # And let's start the logging!
     numeric_level = getattr(logging, debugcfg['LogLevel'].upper(), None)
     if not isinstance(numeric_level, int):
-        raise ValueError('Invalid log level: %s' % loglevel)
+        raise ValueError('Invalid log level: {0!s}'.format(loglevel))
     consoleHandler.setLevel(numeric_level)
     fileHandler.setLevel(numeric_level)
 


### PR DESCRIPTION
This pull request automatically fixes all occurrences of the following issue:

Issue type: [Prefer `format()` over string interpolation operator](https://www.quantifiedcode.com/app/issue_class/4ACGxFj1)
Issue details: [https://www.quantifiedcode.com/app/project/gh:mashedkeyboard:Dashday?groups=code_patterns/%3A4ACGxFj1](https://www.quantifiedcode.com/app/project/gh:mashedkeyboard:Dashday?groups=code_patterns/%3A4ACGxFj1)

To adjust the commit message or the actual code changes, just [rebase](https://git-scm.com/docs/git-rebase) or [cherry-pick](https://git-scm.com/docs/git-cherry-pick) the commits.
For questions or feedback reach out to cody@quantifiedcode.com.

Legal note: We won't claim any copyrights on the code changes.

Cheers,
[Cody - Your code quality bot](https://www.quantifiedcode.com/cody)
